### PR TITLE
Removes extraneous empty column in the troublet output

### DIFF
--- a/troublet/src/main.rs
+++ b/troublet/src/main.rs
@@ -169,7 +169,7 @@ fn call_doublets(params: &Params, mut cluster_allele_counts: FnvHashMap<(usize,u
             let mut assignment: Vec<String> = Vec::new(); assignment.push(cell_barcode.to_string());
             if best_singleton_log_prob > best_doublet_log_prob {
                 if singlet_posterior > params.singlet_threshold {
-                    assignment.push(format!("singlet\t{}\t{}\t{}\t", best_singlet, best_singleton_log_prob, best_doublet_log_prob));
+                    assignment.push(format!("singlet\t{}\t{}\t{}", best_singlet, best_singleton_log_prob, best_doublet_log_prob));
                     //print!("{}\tsinglet\t{}\t{}\t{}\t", cell_barcode, best_singlet, best_singleton_log_prob, best_doublet_log_prob);
                 } else {
                     //if !all_removed.contains(&cell) {
@@ -177,7 +177,7 @@ fn call_doublets(params: &Params, mut cluster_allele_counts: FnvHashMap<(usize,u
                     //    new_removed.push(cell);
                     //    eprintln!("removing {} as unassigned", cell_barcode);
                     //}
-                    assignment.push(format!("unassigned\t{}\t{}\t{}\t",best_singlet, best_singleton_log_prob, best_doublet_log_prob)); 
+                    assignment.push(format!("unassigned\t{}\t{}\t{}",best_singlet, best_singleton_log_prob, best_doublet_log_prob)); 
                     //print!("{}\tunassigned\t{}\t{}\t{}\t", cell_barcode, best_singlet, best_singleton_log_prob, best_doublet_log_prob);
                 }
             } else {
@@ -189,7 +189,7 @@ fn call_doublets(params: &Params, mut cluster_allele_counts: FnvHashMap<(usize,u
                         eprintln!("removing {} as doublet", cell_barcode);
                     }
                     
-                    assignment.push(format!("doublet\t{}/{}\t{}\t{}\t", best_doublet1, best_doublet2,best_singleton_log_prob, best_doublet_log_prob));
+                    assignment.push(format!("doublet\t{}/{}\t{}\t{}", best_doublet1, best_doublet2,best_singleton_log_prob, best_doublet_log_prob));
                     //print!("{}\tdoublet\t{}/{}\t{}\t{}\t", cell_barcode, best_doublet1, best_doublet2, best_singleton_log_prob, best_doublet_log_prob);
                 } else {
                     //if !all_removed.contains(&cell) {
@@ -197,7 +197,7 @@ fn call_doublets(params: &Params, mut cluster_allele_counts: FnvHashMap<(usize,u
                     //    new_removed.push(cell);
                     //    eprintln!("removing {} as unassigned doublet", cell_barcode);
                    // }
-                    assignment.push(format!("unassigned\t{}/{}\t{}\t{}\t",best_doublet1, best_doublet2, best_singleton_log_prob, best_doublet_log_prob));
+                    assignment.push(format!("unassigned\t{}/{}\t{}\t{}",best_doublet1, best_doublet2, best_singleton_log_prob, best_doublet_log_prob));
                     //print!("{}\tunassigned\t{}/{}\t{}\t{}\t", cell_barcode, best_doublet1, best_doublet2, best_singleton_log_prob, best_doublet_log_prob); 
                 }
             }


### PR DESCRIPTION
Because the code that prints out the assignments in troublet already adds a tab character, adding tabs to the end of the assignment string made an extra empty column for every row except the header. This just removes the extra tab.