### PR TITLE
Update the parameters of freebayes in step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ samtools index minitagged_sorted.bam
 You may wish to break this into multiple jobs such as 1 job per chromosome and merge after but the basic command is the following.
 Requires [freebayes](https://github.com/ekg/freebayes) and add /path/to/freebayes/bin to your PATH
 ```
-freebayes -f <reference_fasta> -iXu -C 2 -q 20 -n 3 -E 1 -m 30 --min-coverage 6 --max-coverage 100000 minitagged_sorted.bam
+freebayes -f <reference_fasta> -iXu -C 2 -q 20 -n 3 -E 1 -m 30 --min-coverage 6 --skip-coverage 100000 minitagged_sorted.bam
 ```
 
 ### 3. Cell allele counting 


### PR DESCRIPTION
In freebayes --max-coverage is removed. 
According to [pipline](https://github.com/wheaton5/souporcell/blob/54fd312ce30da931f56f0b524f6bb3a7faf4031d/souporcell_pipeline.py#L447C1-L449C132) , we could instead use --skip-coverage, which is not shown in step by step mannual