### PR TITLE
Feat: Add souporcell3

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ OPTIONS:
             tsv with barcodes and their known assignments
 
     -g, --known_genotypes <known_genotypes>
-            population vcf/bcf of known genotypes if available.
+            NOT YET IMPLEMENTED population vcf/bcf of known genotypes if available.
 
         --known_genotypes_sample_names <known_genotypes_sample_names>...
-            sample names, must be samples from the known_genotypes vcf
+            NOT YET IMPLEMENTED sample names, must be samples from the known_genotypes vcf
 
         --min_alt <min_alt>
             minimum number of cells containing the alt allele for the variant to be used for clustering
@@ -288,7 +288,7 @@ souporcell -a alt.mtx -r ref.mtx -b barcodes.tsv -k <num_clusters> -t 8 > cluste
 If you are clustering more than 16 samples, use Souporcell3 with k harmonic means clustering.
 (This enables multiple runs with bad cluster center reinitialization)
 ```
-souporcell -a alt.mtx -r ref.mtx -b barcodes.tsv -k <num_clusters> -t 8 -s3 true -m khm > clusters_tmp.tsv
+souporcell -a alt.mtx -r ref.mtx -b barcodes.tsv -k <num_clusters> -t 8 -s true -m khm > clusters_tmp.tsv
 ```
 
 ### 5. Calling doublets

--- a/souporcell/src/main.rs
+++ b/souporcell/src/main.rs
@@ -153,7 +153,7 @@ fn bad_cluster_detection (run: usize, num_clusters: usize, best_log_probabilitie
     if num_clusters < 16 || run == 0 {
         return vec![];
     }
-    let mut assigned_vec: Vec<(usize, usize)> = vec![(0, 0); num_clusters];
+    let mut assigned_vec: Vec<(usize, usize)> = (0..num_clusters).map(|i| (i, 0)).collect();
     let mut replace_clusters= vec![];
     // find the cluster which has lowest loss for each cell
     for final_log_probability in best_log_probabilities {
@@ -162,9 +162,10 @@ fn bad_cluster_detection (run: usize, num_clusters: usize, best_log_probabilitie
         assigned_vec[index_of_max].1 += 1;
     }
     assigned_vec.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
-    // outlier first and fourth quaters
-    let cut_off_index_low = 1 * (assigned_vec.len() / 8);
-    let cut_off_index_high = 7 * (assigned_vec.len() / 8);
+    // decrease the reinitialization percent with run
+    let run_value = 3 - run; 
+    let cut_off_index_low = run_value * (assigned_vec.len() / 16);
+    let cut_off_index_high = (16 - run_value) * (assigned_vec.len() / 16);
     // add all outliers and ones below MIN to replace cluster
     eprintln!("Cluster Analysis");
     for (index, (cluster, loss)) in assigned_vec.iter().enumerate() {

--- a/souporcell/src/params.yml
+++ b/souporcell/src/params.yml
@@ -87,7 +87,7 @@ args:
         help: min ref umis to use locus for clustering
     - souporcell3:
         long: souporcell3
-        short: s3
+        short: s
         required: false
         takes_value: true
         help: activate bad cluster detection and multiple runs


### PR DESCRIPTION
Changes to README to include information about Souporcell3.
params.yml updated to include two parameters: souporcell3 and clustering_method.
With souporcell3 set to true, bad cluster detection is activated and runs three times if bad clusters are detected. Default is false.
Changing clustering_method to khm uses khm for clustering. Default is em.
Warnings fixed.