### PR TITLE
souporcell_pipeline.py: ensure that logs subdirectory exists

### DIFF
--- a/souporcell_pipeline.py
+++ b/souporcell_pipeline.py
@@ -611,10 +611,10 @@ def resolve_pyscript(name):
     )
 
 #### MAIN RUN SCRIPT
-if os.path.isdir(args.out_dir):
+if os.path.isdir(os.path.join(args.out_dir, "logs")):
     print("restarting pipeline in existing directory " + args.out_dir)
 else:
-    subprocess.check_call(["mkdir", "-p", args.out_dir + "/logs"])
+    os.makedirs(os.path.join(args.out_dir, "logs"), exist_ok=True)
 if not args.skip_remap:
     if not os.path.exists(args.out_dir + "/fastqs.done"):
         (region_fastqs, all_fastqs) = make_fastqs(args)


### PR DESCRIPTION
souporcell looks at whether `out_dir` already exists to identify if it is restarting a pipeline. This is then used to know if it needs to create the `logs` subdirectory.

Why is this an issue for me? I'm using `mktemp -d` to create separate directories for parallel `souporcell_pipeline.py` processes. So I'm passing an existing, but empy, `out_dir` to souporcell. Because souporcell uses whether `out_dir` exists to identify if it is resuming a previous run, it then skips the creation of the `logs` directory, leading to the following error later on:

```
Traceback (most recent call last):
  File "/opt/souporcell/souporcell_pipeline.py", line 631, in <module>
    minimap_tmp_files = remap(args, region_fastqs, all_fastqs)
  File "/opt/souporcell/souporcell_pipeline.py", line 246, in remap
    with open(args.out_dir + "/logs/minimap.err",'w') as minierr:
FileNotFoundError: [Errno 2] No such file or directory: '/scratch/tmp-souporcell-kMN0mH/logs/minimap.err'
```

Actually, the whole condition is unnecessary since `os.makedirs(... exist_ok=True)` will already do the check and only create the directories if needed.